### PR TITLE
Self-host compose: don't gate on remarks service_healthy (it has no healthcheck)

### DIFF
--- a/docker-compose.selfhosted.yml
+++ b/docker-compose.selfhosted.yml
@@ -11,7 +11,11 @@ services:
       redis:
         condition: service_healthy
       remarks:
-        condition: service_healthy
+        # `service_started` (not `service_healthy`): the remarks image does not
+        # define a healthcheck, and requiring `service_healthy` against a service
+        # without one makes `docker compose up` hang/error. Restore to
+        # `service_healthy` once the remarks image exposes a healthcheck.
+        condition: service_started
       on_startup:
         condition: service_completed_successfully
       # Uncomment if you want to use letsencrypt


### PR DESCRIPTION
**Observed:** `docker compose -f docker-compose.selfhosted.yml up` hangs/errors waiting on the `remarks` dependency.

**Root cause:** `app` declares `depends_on: remarks: { condition: service_healthy }`, but the `remarks` image defines no `HEALTHCHECK`, so that condition can never be satisfied.

**Fix:** use `condition: service_started`, with a comment to restore `service_healthy` once the remarks image declares a healthcheck (the `/health` route already exists; the image just doesn't define a `HEALTHCHECK`).

**Why the hosted product is unaffected:** only the self-hosted compose file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
