### PR TITLE
Self-host: accept any spelling of SCRYBBLE_DEPLOYMENT_ENVIRONMENT

### DIFF
--- a/config/scrybble.php
+++ b/config/scrybble.php
@@ -13,7 +13,10 @@ return [
     |                  You can also use this value for development
     | - "commercial": Deployment for multiple (and paid) users
      */
-    'deployment_environment' => strtolower(env("SCRYBBLE_DEPLOYMENT_ENVIRONMENT", 'self-hosted')),
+    'deployment_environment' => match (preg_replace('/[^a-z]/', '', strtolower((string) env("SCRYBBLE_DEPLOYMENT_ENVIRONMENT", 'self-hosted')))) {
+        'commercial' => 'commercial',
+        default => 'self-hosted',
+    },
 
 
     /*


### PR DESCRIPTION
## Problem

`config('scrybble.deployment_environment')` is compared with `===` against the exact strings `self-hosted` and `commercial` in several places:

- `app/Http/Middleware/SelfHostedMiddleware.php` — `!== 'self-hosted'` ⇒ `abort(404)`
- `app/Console/Commands/SetupAdminAccount.php` — `!== 'self-hosted'` ⇒ refuses to run
- `app/Services/OnboardingStateService.php` — `=== 'commercial'`

Today the value is only `strtolower()`-ed, so a self-hoster who writes `SCRYBBLE_DEPLOYMENT_ENVIRONMENT=selfhosted` (no hyphen — an easy and common variant) silently fails every self-hosted check: the middleware 404s the self-host routes and `app:setup-admin-account` won't run, even though they clearly meant self-hosted. It's a frustrating, hard-to-diagnose footgun for self-hosting.

## Fix

Normalize the env value before matching: lowercase and strip non-letters, then map. Anything that isn't `commercial` resolves to `self-hosted`. So `selfhosted`, `self_hosted`, `Self-Hosted`, etc. all work.

The canonical values (`self-hosted`, `commercial`) are unchanged, so existing deployments — including the hosted/commercial one — behave identically.

Part of the same self-hosting hardening as #29 and #30.