### PR TITLE
Self-host: add a health check to the app service

### DIFF
--- a/docker-compose.selfhosted.yml
+++ b/docker-compose.selfhosted.yml
@@ -2,6 +2,12 @@ services:
   app:
     image: "laauurraaa/scrybble-server:latest"
     restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:80/up || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     ports:
       # comment this out if you want to use letsencrypt.
       - "80:80"


### PR DESCRIPTION
## Why

The bundled `docker-compose.selfhosted.yml` ships a health check only on `redis`; the web `app` service has none. So Docker only knows the app container is *running*, not whether it's actually serving — restart policies, `depends_on: service_healthy`, and reverse proxies can't react when the app is up-but-not-ready or has fallen over.

## Change

Add a health check that probes Laravel's built-in endpoint at `/up` (registered in `bootstrap/app.php`). It returns 200 once the framework boots and isn't behind auth or the self-hosted middleware. `curl` is already present in the image.

```yaml
healthcheck:
  test: ["CMD-SHELL", "curl -f http://localhost:80/up || exit 1"]
  interval: 30s
  timeout: 10s
  retries: 3
  start_period: 60s
```

This pings the health route directly, which is the approach preferred in the discussion on #31.

## Why compose-level and not a `HEALTHCHECK` in the image

The related remarks work (#31 → Scrybbling-together/remarks#79) puts the health check in the *image*, which is correct there because the remarks image is single-role (an HTTP server).

The scrybble image is **multi-role** — the same image runs the web server (`apache2-foreground`), Horizon, and one-off `artisan` commands. An image-level `HEALTHCHECK` would be inherited by the Horizon and one-off containers, which don't serve HTTP, and would mark them perpetually unhealthy. Defining the check per-service on `app` only is therefore the right layer for this image.

Independent of the other self-host PRs (#29, #30, #32, #33); off `master`.
