### PR TITLE
Sync: path-based download fallback when ID lookup fails + surface the failure reason

### DIFF
--- a/app/Http/Controllers/SyncController.php
+++ b/app/Http/Controllers/SyncController.php
@@ -49,7 +49,8 @@ class SyncController extends Controller
             "filename" => $sync->filename,
             "id" => $sync->id,
             "completed" => $sync->completed,
-            "error" => $sync->hasError()
+            "error" => $sync->hasError(),
+            "error_message" => $sync->latestError()
         ];
 
         if ($sync->completed) {

--- a/app/Jobs/DownloadRemarkableFileJob.php
+++ b/app/Jobs/DownloadRemarkableFileJob.php
@@ -33,13 +33,16 @@ class DownloadRemarkableFileJob implements ShouldQueue
         ]);
         try {
             if ($this->sync_context->rm_file_id !== null) {
-                // Use ID-based download
-                $results = $RMapi->getById(
-                    $this->sync_context->rm_file_id,
-                    $this->sync_context->input_filename
-                );
+                try {
+                    $results = $RMapi->getById(
+                        $this->sync_context->rm_file_id,
+                        $this->sync_context->input_filename
+                    );
+                } catch (FileNotFoundException $e) {
+                    $this->sync_context->logStep("ID-based download failed, retrying by path");
+                    $results = $RMapi->get($this->sync_context->input_filename);
+                }
             } else {
-                // Use legacy path-based download
                 $results = $RMapi->get($this->sync_context->input_filename);
             }
         } catch (EmptyPathException|NonAbsolutePathException $e) {

--- a/app/Models/Sync.php
+++ b/app/Models/Sync.php
@@ -64,6 +64,11 @@ class Sync extends Model
         return (!$this->completed && $isOld) || $definiteError;
     }
 
+    public function latestError(): ?string
+    {
+        return $this->logs()->where('severity', 'error')->latest('id')->value('message');
+    }
+
     public function complete(): void
     {
         $this->completed = true;
@@ -78,7 +83,8 @@ class Sync extends Model
             'path' => $sync->filename,
             'created_at' => $sync->created_at->diffForHumans(),
             'completed' => $sync->completed,
-            'error' => $sync->hasError()
+            'error' => $sync->hasError(),
+            'error_message' => $sync->latestError()
         ];
     }
 


### PR DESCRIPTION
## Problem

`DownloadRemarkableFileJob` downloads via `rmapi get --id <rm_file_id>` when the plugin supplies an id. For a class of documents — reproduced with the auto-generated **Daily Journal** notebooks and **on-device duplicates** — `get --id` fails with `file doesn't exist`, even though the **same document downloads fine by path** and converts cleanly.

Reproduced directly against the cloud (read-only):

| method | result |
|---|---|
| `rmapi get --id 869060af…` (what the job runs) | ❌ `Error: file doesn't exist` |
| `rmapi get "/Daily Journal/2026-05-31"` (by path) | ✅ 80 KB, real content |
| remarks `/process` on the by-path download | ✅ `{"status":"success"}` → PDF + markdown |

So the document is fine; only the **ID-based** download fails. The job caught the `FileNotFoundException` and returned, so the sync silently produced nothing while Horizon reported the job **done** — and the reason (logged to `sync_logs`) never reached the user.

## Change

1. **Path fallback** — when `getById()` throws `FileNotFoundException`, retry `get()` by path before giving up. Recovers every failing case above (download → convert both succeed).
2. **Surface the reason** — `Sync::latestError()` returns the most recent `severity = 'error'` log message; it's added to the `/api/sync/status` response (and `formatForResponse`) as `error_message`, so the plugin can tell the user *why* a sync failed instead of only that it did. (Plugin side that displays it: separate PR.)

## Notes / trade-offs

- The path fallback can only be ambiguous if two documents share the exact same path; in that case path resolution picks one. That's strictly better than the current total failure, and the surfaced `error_message` still covers genuinely unrecoverable cases.
- Root cause of the `get --id` failure looks like an rmapi/cloud-sync issue (the docs report `Version: 0` yet have content); the fallback makes Scrybble resilient to it regardless.