### PR TITLE
Fix path-based rmapi download (escapeshellarg in Process array mode) + guard against argument injection

### DIFF
--- a/app/Services/RMapi.php
+++ b/app/Services/RMapi.php
@@ -327,8 +327,7 @@ class RMapi
      */
     public function get(string $filePath): array
     {
-        $rmapi_download_path = escapeshellarg($filePath);
-        [$output, $exit_code] = $this->executeRMApiCommand(['get', $rmapi_download_path]);
+        [$output, $exit_code] = $this->executeRMApiCommand(['get', $filePath]);
         if ($exit_code !== 0) {
             if ($output && Str::contains($output->implode(""), "file doesn't exist")) {
                 throw new FileNotFoundException("Failed downloading file, it doesn't seem to exist (have you deleted the file? Otherwise try resyncing the file on your device)");

--- a/app/Services/RMapi.php
+++ b/app/Services/RMapi.php
@@ -327,6 +327,10 @@ class RMapi
      */
     public function get(string $filePath): array
     {
+        // rmapi runs in Process array mode, so a leading "-" in the path would be
+        // parsed as a flag. reMarkable paths are absolute; reject anything else.
+        $folders = AbsolutePath::fromString($filePath);
+
         [$output, $exit_code] = $this->executeRMApiCommand(['get', $filePath]);
         if ($exit_code !== 0) {
             if ($output && Str::contains($output->implode(""), "file doesn't exist")) {
@@ -335,8 +339,6 @@ class RMapi
             throw new RuntimeException('RMapi `get` command failed for an unknown reason');
         }
         $location = $this->getDownloadedZipLocation($filePath)->toRelative();
-
-        $folders = AbsolutePath::fromString($filePath);
 
         $newLocation = static::hashedFilepath($filePath);
         if (!$this->storage->move($location, $newLocation)) {

--- a/app/Services/RMapi.php
+++ b/app/Services/RMapi.php
@@ -327,8 +327,6 @@ class RMapi
      */
     public function get(string $filePath): array
     {
-        // rmapi runs in Process array mode, so a leading "-" in the path would be
-        // parsed as a flag. reMarkable paths are absolute; reject anything else.
         $folders = AbsolutePath::fromString($filePath);
 
         [$output, $exit_code] = $this->executeRMApiCommand(['get', $filePath]);


### PR DESCRIPTION
## Summary

Two related fixes to `RMapi::get()` (path-based download):

1. **Remove a leftover `escapeshellarg()`** that breaks **every** path-based download, because rmapi is run without a shell.
2. **Guard against argument injection** by requiring the path to be absolute before exec.

Together with #35 (fall back to path-based `get()` when `get --id` fails), this restores syncing for documents that reMarkable's API change has made un-resolvable by ID.

---

## Bug 1 — path-based download is broken

`RMapi::get()` shell-escaped the path and then ran rmapi via **Symfony Process in array mode**:

```php
$rmapi_download_path = escapeshellarg($filePath);
[$output, $exit_code] = $this->executeRMApiCommand(['get', $rmapi_download_path]);
```

`executeRMApiCommand()` → `execWithProcess()` builds `new Process(array_merge([$rmapi], $arguments))`. Array mode calls `execvp()` directly — **each element is a literal `argv[]` entry, no shell parses or unquotes anything.** So `escapeshellarg()`'s single quotes reach rmapi verbatim:

| invocation | what rmapi receives | result |
|---|---|---|
| `executeRMApiCommand(['get', escapeshellarg($p)])` | `'/Daily Journal/2026-05-31'` (quotes included) | ❌ `Error: file doesn't exist` |
| `executeRMApiCommand(['get', $p])` | `/Daily Journal/2026-05-31` | ✅ downloads |

This breaks path-based download for **every** path (the quotes corrupt it regardless of spaces).

### How it regressed

The `escapeshellarg()` was correct when it was first added — rmapi ran through a shell at that time (`popen`/`exec`), so escaping kept the shell from expanding `$` and other metacharacters in filenames.

#28 ("Fix shell injections in RMApi") later moved execution to Symfony Process **array mode** (no shell) and removed the now-unnecessary escaping from `find` / `list` / `getById`. The call in `get()` was left in place; in array mode there is no shell to consume the quotes, so they reach rmapi literally and corrupt every path-based download.

This PR completes that move to array mode.

### Why removing it is safe (no security loss)

- The **only** execution path in `RMapi.php` is Process array mode — verified: no `shell_exec`, `exec()`, `popen`, `proc_open`-with-string, or `fromShellCommandline` remain.
- Injection safety now comes from **array mode itself** (no shell ⇒ nothing to inject into), not from escaping. A hostile filename is passed to rmapi as one literal argument it simply can't find — it can never reach a shell.
- This matches what `find` / `list` / `getById` already do: raw args, no escaping.

---

## Bug 2 — guard against argument injection

Array mode stops **shell** injection but not **argument** injection: a path that *starts with* `-` (e.g. `--help`, `-o /tmp/x`) could be parsed by rmapi as a **flag**. Not reachable in normal use (reMarkable paths are always absolute), but worth closing at the exec boundary.

- **`--` end-of-options does not work here** — rmapi's `get` doesn't honour it (verified: `get -- "/Work/Carol"` → exit 1, while `get "/Work/Carol"` → exit 0). So a separator is not an option.
- **Correct guard: require an absolute path.** A flag starts with `-`; a reMarkable path starts with `/`. The method already validated this via `AbsolutePath::fromString($filePath)` — just *after* the download. This PR moves it *before* the exec, so a non-absolute (flag-like) path is rejected before rmapi sees it. Non-absolute input throws `NonAbsolutePathException`, which the caller (`DownloadRemarkableFileJob`) already handles.

```php
public function get(string $filePath): array
{
    // rmapi runs in Process array mode, so a leading "-" in the path would be
    // parsed as a flag. reMarkable paths are absolute; reject anything else.
    $folders = AbsolutePath::fromString($filePath);

    [$output, $exit_code] = $this->executeRMApiCommand(['get', $filePath]);
    ...
```

---

## Test evidence

**Downloads (raw path, the new behaviour)** — 6/6 real documents incl. multi-space names:

```
OK  /Work/Carol                   -> Carol.rmdoc (141369 bytes)
OK  /Work/Av handover             -> Av handover.rmdoc (39408 bytes)
OK  /Work/Office Ops Weekly       -> Office Ops Weekly.rmdoc (61977 bytes)
OK  /Work/Johannes parental leave -> Johannes parental leave.rmdoc (371269 bytes)
OK  /Daily Journal/2026-01-18     -> 2026-01-18.rmdoc (268169 bytes)
OK  /Daily Journal/2026-03-22     -> 2026-03-22.rmdoc (134573 bytes)
---- ok=6 fail=0 ----
```

**Guard** — absolute accepted, flag-like/relative rejected:

```
/Work/Carol                => ACCEPTED (absolute)
/Daily Journal/2026-05-31  => ACCEPTED (absolute)
-foo                       => REJECTED (NonAbsolutePathException)
--id                       => REJECTED (NonAbsolutePathException)
relative/x                 => REJECTED (NonAbsolutePathException)
```

---

## Why this matters now

rmapi's **ID-based** download (`get --id <uuid>`) recently broke **account-wide** — a reMarkable server-side change; the deployed image/rmapi (v0.0.34, Jan‑25 build) and the document IDs are unchanged. The job falls back to **path-based** `get()` (#35), which still resolves — but `get()` itself was broken by the `escapeshellarg` bug above, so the fallback failed too. This PR makes the fallback actually work, with no dependence on rmapi/reMarkable behaviour: it uses the path that still resolves.

## Related

- #35 — fall back to path-based download when `get --id` fails, and surface the failure reason to the client.

